### PR TITLE
fix(tmux): restore-mosh.sh tab quoting

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -16,7 +16,7 @@ Chronological log of non-trivial fixes for this NixOS flake. Newest entries at t
 4. Confirmed `setw -g pane-base-index 1` in tmux.conf means pane indices start at 1, matching save file
 5. Script was created in `431eb4d` (2026-04-02) with the bug from day one — never worked. Renamed in `b772ef7` (2026-04-13), no logic change
 **Fix:** Changed single quotes to `$'...'` ANSI-C quoting on line 8 so `\t` becomes actual tab characters before being passed to tmux.
-**Commit:** `<sha>`
+**Commit:** `fd2c7c0`
 
 ## 2026-04-13 — tpm-submodule-stale-section-name
 

--- a/FIXES.md
+++ b/FIXES.md
@@ -4,6 +4,20 @@ Chronological log of non-trivial fixes for this NixOS flake. Newest entries at t
 
 **Before debugging a new issue, grep this file first** — a past investigation may contain the answer.
 
+## 2026-04-17 — mosh-restore-tab-quoting
+
+**Symptom:** Mosh sessions not restored after tmux-resurrect restore. `restore-mosh.sh` exits silently with status 1 — pane gets default shell instead of reconnecting to the remote host.
+**Affected:** all hosts/users with tmux-resurrect, `dotfiles/default/tmux/scripts/restore-mosh.sh:8`
+**Root cause:** Single-quoted `\t` in `tmux display-message -p` format string. Bash single quotes prevent escape interpretation, and tmux itself doesn't interpret `\t` in format strings either. Result: `pane_id` contains literal `\t` characters (backslash + t) instead of tab characters. All downstream parameter expansion field splitting produces the full unsplit string for session/window/pane, awk matches nothing, `$host` is empty, script skips `exec mosh`.
+**Investigation:**
+1. `bash -x restore-mosh.sh` showed `pane_id='eksno\t5\t1'` with literal backslash-t — no actual tabs
+2. Confirmed `session="${pane_id%%<TAB>*}"` found no tabs to split on, so session=window=pane=full string
+3. Verified save file format uses real tab separators and awk field mapping ($2=session, $3=window, $6=pane, $11=command) is correct
+4. Confirmed `setw -g pane-base-index 1` in tmux.conf means pane indices start at 1, matching save file
+5. Script was created in `431eb4d` (2026-04-02) with the bug from day one — never worked. Renamed in `b772ef7` (2026-04-13), no logic change
+**Fix:** Changed single quotes to `$'...'` ANSI-C quoting on line 8 so `\t` becomes actual tab characters before being passed to tmux.
+**Commit:** `<sha>`
+
 ## 2026-04-13 — tpm-submodule-stale-section-name
 
 **Symptom:** On jorge@lewis, TPM install binding (`prefix + I`) did nothing. Running `ctrl+a r` surfaced `'~/.config/tmux/plugins/tpm/tpm' returned 127` and `'~/.config/tmux/plugins/tmux/catppuccin.tmux' returned 127`. Git status also showed a mysterious staged `new file: dotfiles/tmux/plugins/tpm` at a path that no longer exists in the repo.

--- a/dotfiles/default/tmux/scripts/restore-mosh.sh
+++ b/dotfiles/default/tmux/scripts/restore-mosh.sh
@@ -5,7 +5,7 @@
 save_file="$(readlink -f ~/.local/share/tmux/resurrect/last)"
 [ -f "$save_file" ] || exit 1
 
-pane_id="$(tmux display-message -p '#{session_name}\t#{window_index}\t#{pane_index}')"
+pane_id="$(tmux display-message -p $'#{session_name}\t#{window_index}\t#{pane_index}')"
 session="${pane_id%%	*}"
 rest="${pane_id#*	}"
 window="${rest%%	*}"


### PR DESCRIPTION
## Root cause

`restore-mosh.sh` has been broken since it was introduced in `431eb4d` — it never successfully restored a mosh session.

Line 8 used single quotes around the `tmux display-message -p` format string:
```bash
pane_id="$(tmux display-message -p '#{session_name}\t#{window_index}\t#{pane_index}')"
```

Single quotes prevent bash from interpreting `\t` as tab characters. tmux itself doesn't interpret `\t` in format strings either. Result: `pane_id` contains literal backslash-t instead of tab characters. All downstream parameter expansion field splitting produces the full unsplit string — awk matches nothing, `$host` is empty, script exits 1.

## Fix

Changed single quotes to `$'...'` ANSI-C quoting so `\t` becomes actual tab characters:
```bash
pane_id="$(tmux display-message -p $'#{session_name}\t#{window_index}\t#{pane_index}')"
```

## Verification

Ran the fixed logic against the live tmux session and resurrect save file:
- `xxd` confirms real tab bytes (0x09) in the output
- Field splitting produces correct session/window/pane values
- awk successfully extracts hostname `pluto` from the save file's mosh-client entry
- Before: exit 1 (no host found). After: `exec mosh pluto`

## Git history

| Commit | Date | What happened |
|--------|------|---------------|
| `431eb4d` | 2026-04-02 | Script created with quoting bug — never worked |
| `b772ef7` | 2026-04-13 | Renamed to `default/` path — no logic change |
| `fd2c7c0` | 2026-04-17 | **This fix** — `$'...'` ANSI-C quoting |

## Test plan

- [ ] Kill tmux server, `tmux-resurrect` restore, verify mosh pane reconnects to `pluto`
- [ ] Verify other resurrect process patterns (nvim, ssh, btop) still work
- [ ] Verify non-mosh panes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)